### PR TITLE
Sanitize uid tag values with getString

### DIFF
--- a/src/main/scala/de/stereotypez/Deidentify.scala
+++ b/src/main/scala/de/stereotypez/Deidentify.scala
@@ -111,7 +111,8 @@ class Deidentify() {
     true
   }
   private var _ucleanFunction: CleaningFunction = (att, tag, dsf, tsf) => {
-    att.setString(tag, att.getVR(tag), UIDUtils.createNameBasedUID(att.getBytes(tag)))
+    // Some uid tags may be terminated by a nullbyte and some are not. Sanitize it with getString.
+    att.setString(tag, att.getVR(tag), UIDUtils.createNameBasedUID(att.getString(tag).getBytes))
     true
   }
   private var _kcleanFunction: CleaningFunction = (att, tag, dsf, tsf) => {


### PR DESCRIPTION
Some DICOM creators may put a nullbyte into a UID DICOM tag. Need to sanitize it before deidentification in order to keep the output stable.